### PR TITLE
Meteor 1.2 Compatibility

### DIFF
--- a/packages/jade-compiler/package.js
+++ b/packages/jade-compiler/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Compiler for the meteor-jade template language",
-  version: "0.4.3",
+  version: "0.4.4",
   name: "mquandalle:jade-compiler",
   git: "https://github.com/mquandalle/meteor-jade.git",
   documentation: "../../README.md"
@@ -11,26 +11,25 @@ Npm.depends({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom("METEOR@0.9.0");
+  api.versionsFrom("METEOR@1.2.0.1");
   api.use([
     'underscore',
-    'htmljs',
     'html-tools',
     'blaze-tools',
     'spacebars-compiler'
-  ]);
+  ], ['server']);
   api.use('minifiers', ['server'], { weak: true });
   api.addFiles([
     'lib/lexer.js',
     'lib/parser.js',
     'lib/transpilers.js',
     'lib/exports.js'
-  ]);
+  ], ['server']);
   api.export('JadeCompiler');
 });
 
 Package.onTest(function (api) {
-  api.versionsFrom("METEOR@0.9.0");
+  api.versionsFrom("METEOR@1.2.0.1");
   api.use("tinytest");
   api.use("minifiers");
   api.use("mquandalle:jade-compiler", "server");

--- a/packages/jade-compiler/package.js
+++ b/packages/jade-compiler/package.js
@@ -14,6 +14,7 @@ Package.onUse(function(api) {
   api.versionsFrom("METEOR@1.2.0.1");
   api.use([
     'underscore',
+    'htmljs',
     'html-tools',
     'blaze-tools',
     'spacebars-compiler'

--- a/packages/jade-compiler/versions.json
+++ b/packages/jade-compiler/versions.json
@@ -2,39 +2,39 @@
   "dependencies": [
     [
       "blaze-tools",
-      "1.0.1"
+      "1.0.4"
     ],
     [
       "deps",
-      "1.0.5"
+      "1.0.9"
     ],
     [
       "html-tools",
-      "1.0.2"
+      "1.0.5"
     ],
     [
       "htmljs",
-      "1.0.2"
+      "1.0.5"
     ],
     [
       "meteor",
-      "1.1.3"
+      "1.2.0"
     ],
     [
       "minifiers",
-      "1.1.2"
+      "1.1.7"
     ],
     [
       "spacebars-compiler",
-      "1.0.3"
+      "1.0.7"
     ],
     [
       "tracker",
-      "1.0.3"
+      "1.0.9"
     ],
     [
       "underscore",
-      "1.0.1"
+      "1.0.4"
     ]
   ],
   "pluginDependencies": [],

--- a/packages/jade/package.js
+++ b/packages/jade/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Jade template language",
-  version: "0.4.3_1",
+  version: "0.4.4",
   name: "mquandalle:jade",
   git: "https://github.com/mquandalle/meteor-jade.git",
   documentation: "../../README.md"
@@ -9,11 +9,11 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "compileJade",
   use: [
-    "underscore@1.0.0",
-    "htmljs@1.0.0",
-    "minifiers@1.0.0",
-    "spacebars-compiler@1.0.0",
-    "mquandalle:jade-compiler@0.4.3"
+    "underscore",
+    "htmljs",
+    "minifiers",
+    "spacebars-compiler",
+    "mquandalle:jade-compiler@0.4.4"
   ],
   sources: [
     "plugin/handler.js",
@@ -21,13 +21,13 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function (api) {
-  api.use("blaze@2.0.0");
+  api.use("blaze");
 });
 
 Package.onTest(function (api) {
-  api.versionsFrom("METEOR@0.9.0");
+  api.versionsFrom("METEOR@1.2.0.1");
   api.use("tinytest");
-  api.use(["mquandalle:jade", "ui", "spacebars", "templating"]);
+  api.use(["mquandalle:jade", "ui", "spacebars", "templating", "underscore", "jquery"]);
   api.addFiles([
     "tests/match.jade",
     "tests/match.html",

--- a/packages/jade/versions.json
+++ b/packages/jade/versions.json
@@ -2,27 +2,27 @@
   "dependencies": [
     [
       "meteor",
-      "1.1.3"
+      "1.2.0"
     ],
     [
       "underscore",
-      "1.0.1"
+      "1.0.4"
     ]
   ],
   "pluginDependencies": [
     [
       "compileJade",
       {
-        "spacebars-compiler": "1.0.3",
-        "mquandalle:jade-compiler": "0.4.1",
-        "deps": "1.0.5",
-        "tracker": "1.0.3",
-        "html-tools": "1.0.2",
-        "underscore": "1.0.1",
-        "meteor": "1.1.3",
-        "blaze-tools": "1.0.1",
-        "htmljs": "1.0.2",
-        "minifiers": "1.1.2"
+        "spacebars-compiler": "1.0.7",
+        "mquandalle:jade-compiler": "0.4.4",
+        "deps": "1.0.9",
+        "tracker": "1.0.9",
+        "html-tools": "1.0.5",
+        "underscore": "1.0.4",
+        "meteor": "1.2.0",
+        "blaze-tools": "1.0.4",
+        "htmljs": "1.0.5",
+        "minifiers": "1.1.7"
       }
     ]
   ],


### PR DESCRIPTION
Explicit targets when including packages and files (`server`, `client`, etc).
Resolves #168 and possibly #169

Minimum Meteor version bumped from `0.9.0` to `1.2.0.1`. Meteor 1.2 has breaking
changes so this is not compatible with versions lower than this. I'm not sure
how backwards compatibility should be handled.

Updated `versions.json` files with versions required by Meteor 1.2

Removed hardcoded versions in the build plugin. Rationale is to use the versions
used by Meteor 1.2 or versions set by the developer.

Added `underscore` and `jquery` to the tests as these are no longer global.

Bumped package version up to `0.4.4`
